### PR TITLE
Fixing README.md TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ A web-based tool for building, managing, and converting Docker Compose files, co
 
 ##  Table of Contents
 
-- [Features](#-features)
-- [Quick Start](#-quick-start)
-- [Deployment Options](#-deployment-options)
-- [Usage Guide](#-usage-guide)
-- [Tech Stack](#-tech-stack)
-- [Contributing](#-contributing)
-- [License](#-license)
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Deployment Options](#deployment-options)
+- [Usage Guide](#usage-guide)
+- [Tech Stack](#tech-stack)
+- [Contributing](#contributing)
+- [License](#license)
 
 ---
 


### PR DESCRIPTION
Links all had a leading - and it was preventing the links from working properly.